### PR TITLE
Make the overrides parameter optional

### DIFF
--- a/.changeset/smart-glasses-scream.md
+++ b/.changeset/smart-glasses-scream.md
@@ -1,0 +1,5 @@
+---
+"@synulux/prettier-config": minor
+---
+
+Make the `overrides` parameter optional.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Options } from "prettier";
 
-export function defineConfig(overrides: Options): Options {
+export function defineConfig(overrides: Options = {}): Options {
   return {
     printWidth: 120,
     tabWidth: 2,


### PR DESCRIPTION
## Summary

This pull request makes the `overrides` parameter to be an optional empty object.